### PR TITLE
1 hr but 2 hrs in relative date formatting

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -114,7 +114,8 @@ function formatRelativeDate(timestamp) {
   } else if (delta < 3600) {
     return `${~~(delta / 60)} min ago`;
   } else if (delta < 86400) {
-    return `${~~(delta / 3600)} hrs ago`;
+    const day = ~~(delta / 3600);
+    return day === 1 ? `${day} hr ago` : `${day} hrs ago`;
   } else if (delta < 86400 * 2) {
     return "yesterday";
   } else if (delta < 86400 * 3) {


### PR DESCRIPTION
upstreaming https://github.com/aadibajpai/hustler/commit/a57eeb32b2791760b9b4710a392dd577096f5372

relatively minor but thought it might be useful.

avoids this:

![image](https://user-images.githubusercontent.com/27063113/102626004-4253e580-416c-11eb-97d9-4e8d40ada5ad.png)

from the preview:

![image](https://user-images.githubusercontent.com/27063113/102626156-73ccb100-416c-11eb-9abd-eb0c0ce55749.png)
