### PR TITLE
fix: make hyphens render uniformly

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -18,7 +18,7 @@ body {
 
 body,
 select {
-  font-family: "EB Garamond", "Georgia", "Times New Roman", serif;
+  font-family: "EB Garamond", "Georgia", "Times New Roman", serif, sans-serif;
 }
 
 .app {


### PR DESCRIPTION
the css hyphenation property doesn't work on chrome mac as well as you'd think, so the hyphens don't render properly—causing those weird boxes. I discovered this recently since well, I have a mac now.
![image](https://user-images.githubusercontent.com/27063113/148740211-5f7792e5-2b44-4c47-9844-20f8d2b47316.png)

with the fix:
![image](https://user-images.githubusercontent.com/27063113/148740501-830cdaac-5fdb-4595-9e5b-4d1e04d68c74.png)


This fixes it however, by adding sans serif as a fallback font which does render the hyphen. Figured I'd make a quick pr since it's a good UI fix.